### PR TITLE
Add attributes for td and th

### DIFF
--- a/src/vdom/VDom.hx
+++ b/src/vdom/VDom.hx
@@ -120,9 +120,9 @@ typedef AnchorAttr = {> AttrOf<AnchorElement>,
 
 typedef TableCellAttr = {> Attr,
   @:optional var abbr(default, never):String;
-  @:optional var colspan(default, never):Int;
+  @:optional var colSpan(default, never):Int;
   @:optional var headers(default, never):String;
-  @:optional var rowspan(default, never):Int;
+  @:optional var rowSpan(default, never):Int;
   @:optional var scope(default, never):String;
   @:optional var sorted(default, never):String;
 }

--- a/src/vdom/VDom.hx
+++ b/src/vdom/VDom.hx
@@ -43,8 +43,8 @@ extern class VDom {
   static inline function tbody(attr:EditableAttr, ?children:Children):VNode return h('tbody', attr, children);
   static inline function tfoot(attr:EditableAttr, ?children:Children):VNode return h('tfoot', attr, children);
   static inline function tr(attr:EditableAttr, ?children:Children):VNode return h('tr', attr, children);
-  static inline function td(attr:EditableAttr, ?children:Children):VNode return h('td', attr, children);
-  static inline function th(attr:EditableAttr, ?children:Children):VNode return h('th', attr, children);
+  static inline function td(attr:TableCellAttr, ?children:Children):VNode return h('td', attr, children);
+  static inline function th(attr:TableCellAttr, ?children:Children):VNode return h('th', attr, children);
 
   static inline function h1(attr:EditableAttr, ?children:Children):VNode return h('h1', attr, children);
   static inline function h2(attr:EditableAttr, ?children:Children):VNode return h('h2', attr, children);
@@ -115,6 +115,16 @@ typedef AnchorAttr = {> AttrOf<AnchorElement>,
   @:optional var href(default, never):String;
   @:optional var target(default, never):String;
   @:optional var type(default, never):String;
+}
+
+
+typedef TableCellAttr = {> Attr,
+  @:optional var abbr(default, never):String;
+  @:optional var colspan(default, never):Int;
+  @:optional var headers(default, never):String;
+  @:optional var rowspan(default, never):Int;
+  @:optional var scope(default, never):String;
+  @:optional var sorted(default, never):String;
 }
 
 

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -79,12 +79,25 @@ class RunTests extends haxe.unit.TestCase {
     document.body.appendChild(root);
     root.update(
       #if tink_hxx
-      '<td colspan=${1}>colspan test</td>'
+      '<td colSpan=${1}>colspan test</td>'
       #else
-      td({ colspan: 1 }, ['colspan test'])
+      td({ colSpan: 1 }, ['colspan test'])
       #end
     );
     assertTrue(root.currentElement().getAttribute('colspan') == '1');
+  }
+  
+  function testRowspan() {
+    var root = new vdom.VRoot();
+    document.body.appendChild(root);
+    root.update(
+      #if tink_hxx
+      '<td rowSpan=${1}>rowspan test</td>'
+      #else
+      td({ rowSpan: 1 }, ['rowspan test'])
+      #end
+    );
+    assertTrue(root.currentElement().getAttribute('rowspan') == '1');
   }
 
   static function main() {

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -73,6 +73,19 @@ class RunTests extends haxe.unit.TestCase {
     var style:Style = 'height:32%';
     assertTrue(style.height == '32%');
   }
+  
+  function testColspan() {
+    var root = new vdom.VRoot();
+    document.body.appendChild(root);
+    root.update(
+      #if tink_hxx
+      '<td colspan=${1}>colspan test</td>'
+      #else
+      td({ colspan: 1 }, ['colspan test'])
+      #end
+    );
+    assertTrue(root.currentElement().getAttribute('colspan') == '1');
+  }
 
   static function main() {
     var runner = new haxe.unit.TestRunner();


### PR DESCRIPTION
But there is a problem, even the generated code writes:

```js
vdom_VDom.h("th",{ colspan : 1},["children"]);
```

The result html doesn't have the colspan attribute. Probably a bug somewhere

Attached a failing test.