### PR TITLE
Add value attribute to textarea

### DIFF
--- a/src/vdom/VDom.hx
+++ b/src/vdom/VDom.hx
@@ -158,6 +158,7 @@ typedef TextAreaAttr = {> AttrOf<TextAreaElement>,
   @:optional var readOnly(default, never):Bool;
   @:optional var required(default, never):Bool;
   @:optional var rows(default, never):Int;
+  @:optional var value(default, never):String;
   @:optional var wrap(default, never):String;
 }
 


### PR DESCRIPTION
textarea has a js attribute "value"

inner html doesn't guarantee to work at all times somehow.